### PR TITLE
Add GUI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ A simple Python project template that follows best practices and PEP8 guidelines
 - ✅ Ready for testing and linting
 - ✅ **Git commit and push functionality**
 - ✅ **Command-line argument parsing**
+- ✅ **GUI mode with `--gui` option**
+
+### GUI Usage
+
+Launch the graphical interface with:
+
+```bash
+python main.py --gui
+```
 
 ## Project Structure
 

--- a/main.py
+++ b/main.py
@@ -11,6 +11,9 @@ import subprocess
 import sys
 from typing import Optional
 
+import tkinter as tk
+from tkinter import messagebox
+
 
 def greet(name: Optional[str] = None) -> str:
     """
@@ -63,6 +66,46 @@ def git_commit_and_push(commit_message: str) -> bool:
         return False
 
 
+def run_gui() -> None:
+    """Run the application in GUI mode."""
+
+    def on_greet() -> None:
+        message = greet(name_var.get() or None)
+        output_var.set(message)
+
+    def on_commit() -> None:
+        msg = commit_var.get()
+        if not msg:
+            messagebox.showerror("Error", "Commit message cannot be empty")
+            return
+        success = git_commit_and_push(msg)
+        if success:
+            messagebox.showinfo("Success", "Changes committed and pushed")
+        else:
+            messagebox.showerror("Error", "Git operation failed")
+
+    root = tk.Tk()
+    root.title("Hello World GUI")
+
+    name_var = tk.StringVar()
+    commit_var = tk.StringVar()
+    output_var = tk.StringVar()
+
+    tk.Label(root, text="Name:").grid(row=0, column=0, padx=5, pady=5, sticky="e")
+    tk.Entry(root, textvariable=name_var).grid(row=0, column=1, padx=5, pady=5)
+
+    tk.Button(root, text="Greet", command=on_greet).grid(row=0, column=2, padx=5, pady=5)
+
+    tk.Label(root, text="Commit message:").grid(row=1, column=0, padx=5, pady=5, sticky="e")
+    tk.Entry(root, textvariable=commit_var).grid(row=1, column=1, padx=5, pady=5)
+
+    tk.Button(root, text="Commit", command=on_commit).grid(row=1, column=2, padx=5, pady=5)
+
+    tk.Label(root, textvariable=output_var).grid(row=2, column=0, columnspan=3, padx=5, pady=10)
+
+    root.mainloop()
+
+
 def parse_arguments() -> argparse.Namespace:
     """
     Parse command-line arguments.
@@ -85,6 +128,11 @@ def parse_arguments() -> argparse.Namespace:
         help="Name to greet",
         default=None
     )
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help="Run the application in GUI mode"
+    )
     
     return parser.parse_args()
 
@@ -99,6 +147,10 @@ def main() -> None:
     # Parse command-line arguments
     args = parse_arguments()
     
+    if args.gui:
+        run_gui()
+        return
+
     # If commit message is provided, perform git operations
     if args.commit:
         success = git_commit_and_push(args.commit)


### PR DESCRIPTION
## Summary
- add a Tkinter GUI for greeting and git commit
- introduce `--gui` command-line option
- document GUI usage in README

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683f422a99b48332857d1d84395239d7